### PR TITLE
host config for heroku deployemnts

### DIFF
--- a/archetype/config/web.js
+++ b/archetype/config/web.js
@@ -66,7 +66,12 @@ module.exports = {
   /**
    * The port to bind the web server to
    */
-  port: process.env.PORT || 3000
+  port: process.env.PORT || 3000,
+
+  /**
+   * The host to bind the web server to
+   */
+  host: process.env.HOST || '0.0.0.0'
 
   /**
    * Alternate method to add multiple template engine, for single view template use config.views.engine


### PR DESCRIPTION
Right now when you try to deploy new Trails application to heroku it will fail (even without `trailpack-repl` with this error: 
`Error R10 (Boot timeout) -> Web process failed to bind to $PORT within 60 seconds of launch`

This fix will correctly bind trails application to heroku instance