### PR TITLE
Request data (headers, params, query, body) typecasting with enabled validation

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -268,6 +268,10 @@ module.exports = {
                   return next(new errors.ValidationError(err))
                 }
                 else {
+                  req.headers = result.headers
+                  req.params = result.params
+                  req.query = result.query
+                  req.body = result.body
                   next()
                 }
               })

--- a/test/api/controllers/ValidationController.js
+++ b/test/api/controllers/ValidationController.js
@@ -14,4 +14,12 @@ module.exports = class ValidationController extends Controller {
   success(req, res) {
     res.status(200).json()
   }
+  sendRequestData(req, res) {
+    res.status(200).json({
+      headers: req.headers,
+      query: req.query,
+      params: req.params,
+      body: req.body
+    })
+  }
 }

--- a/test/app.js
+++ b/test/app.js
@@ -228,6 +228,28 @@ const App = {
         }
       }
     }, {
+      method: ['GET', 'POST'],
+      path: '/validation/sendRequestData/:numberParam',
+      handler: 'ValidationController.sendRequestData',
+      config: {
+        validate: {
+          headers: Joi.object({
+            'numberheader': Joi.number()
+          }).options({
+            allowUnknown: true
+          }),
+          query: Joi.object({
+            number: Joi.number()
+          }),
+          params: Joi.object({
+            numberParam: Joi.number()
+          }),
+          payload: Joi.object({
+            number: Joi.number()
+          })
+        }
+      }
+    }, {
       method: 'GET',
       path: '/node_modules',
       handler: {

--- a/test/integration/validation.test.js
+++ b/test/integration/validation.test.js
@@ -195,6 +195,35 @@ describe('express4 controllers', () => {
             done(err)
           })
       })
+      it('should return 200 on GET /validation/sendRequestData/123 with typecasted request data (headers, query, params, body)', (done) => {
+        request
+          .get('/validation/sendRequestData/1?number=2')
+          .set('accept', 'application/json')
+          .set('numberheader', '3')
+          .expect(200)
+          .end((err, res) => {
+            assert.deepStrictEqual(res.body.params.numberParam, 1)
+            assert.deepStrictEqual(res.body.query.number, 2)
+            assert.deepStrictEqual(res.body.headers.numberheader, 3)
+            done(err)
+          })
+      })
+      it('should return 200 on POST /validation/sendRequestData/123 with typecasted request data (headers, query, params, body)', (done) => {
+        request
+          .get('/validation/sendRequestData/1')
+          .set('accept', 'application/json')
+          .set('numberheader', '3')
+          .send({
+            'number': '2'
+          })
+          .expect(200)
+          .end((err, res) => {
+            assert.deepStrictEqual(res.body.params.numberParam, 1)
+            assert.deepStrictEqual(res.body.body.number, 2)
+            assert.deepStrictEqual(res.body.headers.numberheader, 3)
+            done(err)
+          })
+      })
     })
   })
 })


### PR DESCRIPTION
If `validate` configured for route, merge Joi validation result with `req`.