### PR TITLE
Define req.query instead of assign

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -270,7 +270,7 @@ module.exports = {
                 else {
                   req.headers = result.headers
                   req.params = result.params
-                  req.query = result.query
+                  Object.defineProperty(req, 'query', {value: result.query})
                   req.body = result.body
                   next()
                 }


### PR DESCRIPTION
Fix for error: `TypeError: Cannot set property query of #<IncomingMessage> which has only a getter`
Node version: 7.1.0
