### PR TITLE
unload can be called before webserver started

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,10 @@ module.exports = class Express extends ServerTrailpack {
   }
 
   unload() {
-    if (_.isArray(lib.Server.nativeServer)) {
+    if (lib.Server.nativeServer === null) {
+      return
+    }
+    else if (_.isArray(lib.Server.nativeServer)) {
       lib.Server.nativeServer.forEach(server => {
         server.close()
       })


### PR DESCRIPTION
other trailpack initialization can fail and app will stop
in this case you will get error
```bash
(node:2451) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 2): TypeError: Cannot read property 'close' of null
(node:2451) DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.

```