### PR TITLE
footprint add possibility to ignore models

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ node_js:
 - 5
 - 6
 - 7
+- 8
 before_install: if [[ `npm -v` != 3* ]]; then npm i -g npm@3; fi
 notifications:
   email: false

--- a/api/policies/FootprintPolicy.js
+++ b/api/policies/FootprintPolicy.js
@@ -13,12 +13,22 @@ const Policy = require('trails/policy')
  * @see http://expressjs.com/en/4x/api.html#req
  */
 module.exports = class Footprint extends Policy {
+  _isModelIgnored(req) {
+    const ignoredModels = _.get(this.app.config, 'footprints.models.ignore', []).map(value => {
+      return value.toLowerCase()
+    })
+    return req.params.model ? ignoredModels.indexOf(req.params.model.toLowerCase()) != -1 :
+      ignoredModels.indexOf(req.params.parentModel.toLowerCase()) != -1
+  }
 
   /**
    * Create Policy.
    * @see FootprintController.create
    */
   create(req, res, next) {
+    if (this._isModelIgnored(req)) {
+      return res.boom.forbidden(this.__('errors.footprints.forbidden'))
+    }
     if (!_.isPlainObject(req.body) && !_.isArray(req.body)) {
       return res.boom.preconditionFailed(this.__('errors.footprints.body'))
     }
@@ -31,6 +41,9 @@ module.exports = class Footprint extends Policy {
    * @see FootprintController.find
    */
   find(req, res, next) {
+    if (this._isModelIgnored(req)) {
+      return res.boom.forbidden(this.__('errors.footprints.forbidden'))
+    }
     const criteria = this.app.packs.express.getCriteriaFromQuery(req.query)
 
     if (req.params.id && !_.isEmpty(criteria)) {
@@ -45,6 +58,9 @@ module.exports = class Footprint extends Policy {
    * @see FootprintController.update
    */
   update(req, res, next) {
+    if (this._isModelIgnored(req)) {
+      return res.boom.forbidden(this.__('errors.footprints.forbidden'))
+    }
     if (req.params.id && !_.isEmpty(req.query)) {
       return res.boom.preconditionFailed(this.__('errors.footprints.update.mutex'))
     }
@@ -57,6 +73,9 @@ module.exports = class Footprint extends Policy {
    * @see FootprintController.destroy
    */
   destroy(req, res, next) {
+    if (this._isModelIgnored(req)) {
+      return res.boom.forbidden(this.__('errors.footprints.forbidden'))
+    }
     if (req.params.id && !_.isEmpty(req.query)) {
       return res.boom.preconditionFailed(this.__('errors.footprints.destroy.mutex'))
     }
@@ -69,6 +88,9 @@ module.exports = class Footprint extends Policy {
    * @see FootprintController.createAssociation
    */
   createAssociation(req, res, next) {
+    if (this._isModelIgnored(req)) {
+      return res.boom.forbidden(this.__('errors.footprints.forbidden'))
+    }
     if (!_.isPlainObject(req.body)) {
       return res.boom.preconditionFailed(this.__('errors.footprints.body'))
     }
@@ -81,6 +103,9 @@ module.exports = class Footprint extends Policy {
    * @see FootprintController.findAssociation
    */
   findAssociation(req, res, next) {
+    if (this._isModelIgnored(req)) {
+      return res.boom.forbidden(this.__('errors.footprints.forbidden'))
+    }
     const criteria = this.app.packs.express.getCriteriaFromQuery(req.query)
     if (req.params.childId && !_.isEmpty(criteria)) {
       return res.boom.preconditionFailed(this.__('errors.footprints.find.mutex'))
@@ -94,6 +119,9 @@ module.exports = class Footprint extends Policy {
    * @see FootprintController.updateAssociation
    */
   updateAssociation(req, res, next) {
+    if (this._isModelIgnored(req)) {
+      return res.boom.forbidden(this.__('errors.footprints.forbidden'))
+    }
     if (req.params.childId && !_.isEmpty(req.query)) {
       return res.boom.preconditionFailed(this.__('errors.footprints.update.mutex'))
     }
@@ -106,6 +134,9 @@ module.exports = class Footprint extends Policy {
    * @see FootprintController.destroyAssociation
    */
   destroyAssociation(req, res, next) {
+    if (this._isModelIgnored(req)) {
+      return res.boom.forbidden(this.__('errors.footprints.forbidden'))
+    }
     if (req.params.childId && !_.isEmpty(req.query)) {
       return res.boom.preconditionFailed(this.__('errors.footprints.destroy.mutex'))
     }

--- a/test/api/models/Ignored.js
+++ b/test/api/models/Ignored.js
@@ -1,0 +1,23 @@
+'use strict'
+
+const Model = require('trails/model')
+
+/**
+ * Ignored
+ *
+ * @description A Ignored model
+ */
+module.exports = class User extends Model {
+  static config(app, Sequelize) {
+    return {}
+  }
+
+  static schema(app, Sequelize) {
+    return {
+      name: {
+        type: Sequelize.STRING,
+        allowNull: false
+      }
+    }
+  }
+}

--- a/test/api/models/index.js
+++ b/test/api/models/index.js
@@ -1,2 +1,3 @@
 exports.User = require('./User')
+exports.Ignored = require('./Ignored')
 exports.Role = require('./Role')

--- a/test/app.js
+++ b/test/app.js
@@ -31,7 +31,7 @@ const App = {
         ignore: ['DefaultController', 'ViewController', 'StandardController']
       },
       models: {
-
+        ignore: ['Ignored'],
         actions: {
           create: true,
           createWithId: true,

--- a/test/integration/footprint.test.js
+++ b/test/integration/footprint.test.js
@@ -9,6 +9,68 @@ describe('FootprintController', () => {
     request = supertest('http://localhost:3000/api/v1')
   })
 
+  describe('#ignored model', () => {
+    it('should not insert a record', done => {
+      request
+        .post('/ignored')
+        .send({
+          name: 'createtest1'
+        })
+        .expect(403)
+        .end((err, res) => {
+          assert.equal(res.body.message, 'errors.footprints.forbidden')
+          assert.equal(res.body.error, 'Forbidden')
+          done(err)
+        })
+    })
+    it('should not find', done => {
+      request
+        .get('/ignored/' + userId)
+        .expect(403)
+        .end((err, res) => {
+          assert.equal(res.body.message, 'errors.footprints.forbidden')
+          assert.equal(res.body.error, 'Forbidden')
+          done(err)
+        })
+    })
+    it('should not update', done => {
+      request
+        .put('/ignored/' + userId)
+        .send({
+          name: 'updatetest2'
+        })
+        .expect(403)
+        .end((err, res) => {
+          assert.equal(res.body.message, 'errors.footprints.forbidden')
+          assert.equal(res.body.error, 'Forbidden')
+          done(err)
+        })
+    })
+    it('should not destroy', done => {
+      request
+        .del('/ignored/' + userId)
+        .expect(403)
+        .end((err, res) => {
+          assert.equal(res.body.message, 'errors.footprints.forbidden')
+          assert.equal(res.body.error, 'Forbidden')
+          done(err)
+        })
+    })
+    it('should not insert an associated record', done => {
+      request
+        .post('/ignored/' + userId + '/roles')
+        .send({
+          name: 'associatedroletest1'
+        })
+        .expect(403)
+        .end((err, res) => {
+          assert.equal(res.body.message, 'errors.footprints.forbidden')
+          assert.equal(res.body.error, 'Forbidden')
+          done(err)
+        })
+    })
+  })
+
   describe('#create', () => {
     it('should insert a record', done => {
       request


### PR DESCRIPTION
Now with this, under config.footprint.models we can have an array of ignored models like controllers, if a footprint is called on an ignored model a 403 is returned