### PR TITLE
Allow unload after initialize to trigger closing of the server properly

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,17 +60,25 @@ module.exports = class Express extends ServerTrailpack {
   }
 
   unload() {
+    if (lib.Server.nativeServer.listening) {
+      this.closeServer()
+    }
+    else {
+      this.app.on('webserver:http:ready', () => this.closeServer())
+    }
+  }
+
+  closeServer() {
     if (lib.Server.nativeServer === null) {
       return
     }
-    else if (_.isArray(lib.Server.nativeServer)) {
-      lib.Server.nativeServer.forEach(server => {
-        server.close()
-      })
+
+    let servers = lib.Server.nativeServer
+    if (!_.isArray(lib.Server.nativeServer)) {
+      servers = [servers]
     }
-    else {
-      lib.Server.nativeServer.close()
-    }
+
+    servers.forEach(server => server.close())
   }
 
   constructor(app) {


### PR DESCRIPTION
Closes #57 

## Changes

  - Added a new `closeServer` function from the refactored `unload` function
  - On call of unload
    - Check if server is running with `listening` https://nodejs.org/api/http.html#http_server_listening
    - If server haven't started, wait for event to emit specified in `initialize` function
